### PR TITLE
check if str is file path instead of type strings

### DIFF
--- a/scenarious/scenario.py
+++ b/scenarious/scenario.py
@@ -1,6 +1,7 @@
 import yaml
 import six
 import traceback
+import os
 from functools import partial
 from collections import OrderedDict
 
@@ -54,7 +55,7 @@ class Scenario(object):
         if isinstance(source, dict):
             raw = source
         else:
-            raw = yaml.load(open(source) if isinstance(source, six.string_types) else source)
+            raw = yaml.load(open(source) if os.path.isfile(str(source)) else source)
 
         for entity, value in (raw or {}).items():
             objects = [{}] * value if isinstance(value, int) else value


### PR DESCRIPTION
When doing 

```
ScenarioFactory("""
        accounts:
          - username: Think Geek
        users:
          - account_id: $account_1.id
        warehouses:
          - from_name: Test Warehouse
            account_id: $account_1.id
            from_address1: 55 W Railroad Ave
            from_address2: Building 4
            from_zip: 10923...
```
and tries to update, the string is interpreted as a path to a file

```
  def update(self, source):
        if isinstance(source, dict):
            raw = source
        else:
           raw = yaml.load(open(source) if isinstance(source, six.string_types) else source)
E           IOError: [Errno 36] File name too long: u"\n        accounts:\n          - username: Think Geek\n        users:\n          - account_id: $account_1.id\n        warehouses:\n          - from_name: Test Warehouse\n            account_id: $account_1.id\n            from_address1: 55 W Railroad Ave\n            from_address2: Building 4\n            from_zip: 10923\n            from_city: New York\n  
```
`isinstance(source, six.string_types)  == True`