### PR TITLE
Adding the ability to access objects directly with identifiers 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 -r requirements.txt
 pytest
 tox
+ipython
+ipdb

--- a/scenarious/scenario.py
+++ b/scenarious/scenario.py
@@ -94,7 +94,7 @@ class Scenario(object):
             type_name = self._get_type_name(key)
 
             if self._entity_store.has_type(type_name):
-                return list(self._entity_store.all(type_name))
+                return self._entity_store.all(type_name)
 
             else:
                 raise AttributeError("%s doesn't have type '%s'" % (self.__class__.__name__, type_name))


### PR DESCRIPTION
Currently, if we want to access an object inside a test case we have to use list indexes or `by_id` method:

example:

```python
        s = Scenario.load(StringIO("""
        actors:
          - name: test
            age: 20

        movies:
          - title: test movie
            genre: drama
            year: 2018
        """), type_handlers=[ActorTypeHandler, MovieTypeHandler])

        assert 'test' == s.actors[0].name
        # OR
        assert 'test' == s.by_id('actors', 1)
```

There are a few problems with this approach:
* When you have many objects per type you have to use zero-based-indexes in a list which is kind of annoying
* Using indexes isn't that simple and doesn't match the object access we have in the yaml scenarios (identifier access)
* I find using `by_id` method a little too verbose

With this PR I'm implementing access to the objects using the identifier directly, so you could do this:

```python
        s = Scenario.load(StringIO("""
        actors:
          - name: test
            age: 20

        movies:
          - title: test movie
            genre: drama
            year: 2018
        """), type_handlers=[ActorTypeHandler, MovieTypeHandler])

        assert 'test' == s.actors.actor_1.name
```

It works with aliases too!

```python
s = Scenario.load(StringIO("""
        actors:
          - id: 1
            _alias: test1
            name: test1
            age: 20

          - id: 3
            name: test2
            age: 22
        """), type_handlers=[ActorTypeHandler, MovieTypeHandler])

        assert 'test1' == s.actors.actor_test1.name
```

This will make working with scenarios in tests much more comfortable.

**NOTE: I didn't get rid of the support for list indexes since I don't want to break our entire codebase :rofl:   they're both supported, we could migrate this and slowly start migrating tests to this approach or just write the new ones this way**