### PR TITLE
Fix ModuleLoader.load failing on invalid or non existing paths

### DIFF
--- a/scenarious/scenario.py
+++ b/scenarious/scenario.py
@@ -54,7 +54,7 @@ class Scenario(object):
         if isinstance(source, dict):
             raw = source
         else:
-            raw = yaml.load(open(source) if isinstance(source, six.string_types) else source)
+            raw = yaml.full_load(open(source) if isinstance(source, six.string_types) else source)
 
         for entity, value in (raw or {}).items():
             objects = [{}] * value if isinstance(value, int) else value

--- a/scenarious/util.py
+++ b/scenarious/util.py
@@ -63,8 +63,9 @@ class ModuleLoader(object):
     def load(cls, paths=None, force=False):
         if cls._modules is None or force:
             cls._modules = []
-            loaded_files = []
-            _path = paths or cls.group_path
+            loaded_files = [] 
+            cls.group_path = [] if cls.group_path is None else cls.group_path
+            _path = paths or cls.group_path 
             _path = _path if type(_path) is list else [_path]
 
             for _p in _path:
@@ -73,7 +74,7 @@ class ModuleLoader(object):
                         if not cls.is_allowed_file(subfile):
                             continue
 
-                        module_name, module_ext = subfile.split('.')
+                        module_name, module_ext = os.path.splitext(subfile)
 
                         if module_name != '__init__' and module_ext == 'py':
                             submodule_path = os.path.join(path, subfile)

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -1,0 +1,21 @@
+from scenarious.util import ModuleLoader
+
+
+def test_module_loader_load_empty():
+    actual = ModuleLoader.load(paths=[])
+    expected = []
+    assert actual == expected
+    actual = ModuleLoader.load()
+    assert actual == expected
+
+
+def test_module_loader_invalid_paths():
+    actual = ModuleLoader.load(paths=["./fixtures/test.yml", "test.txt", "test.py"])
+    expected = []
+    assert actual == expected
+
+
+def test_module_loader_valid_paths():
+    actual = ModuleLoader.load(paths=["test.py"])
+    expected = []
+    assert actual == expected


### PR DESCRIPTION
Added tests cases exposing the behavior.